### PR TITLE
Challenge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "sqlite3", ">= 2.1"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
-# gem "jbuilder"
+gem "jbuilder"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile
+++ b/Gemfile
@@ -44,4 +44,7 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  # Factories for tests
+  gem "factory_bot_rails"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -47,4 +47,7 @@ group :development, :test do
 
   # Factories for tests
   gem "factory_bot_rails"
+
+  # JSON Schema validation for API responses in tests
+  gem "json_schemer"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,11 @@ GEM
     erubi (1.13.1)
     et-orbi (1.3.0)
       tzinfo
+    factory_bot (6.5.5)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.1)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
     fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -159,6 +164,8 @@ GEM
     nokogiri (1.18.10-arm-linux-musl)
       racc (~> 1.4)
     nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -276,6 +283,7 @@ GEM
     sqlite3 (2.7.3-arm-linux-gnu)
     sqlite3 (2.7.3-arm-linux-musl)
     sqlite3 (2.7.3-arm64-darwin)
+    sqlite3 (2.7.3-x86_64-darwin)
     sqlite3 (2.7.3-x86_64-linux-gnu)
     sqlite3 (2.7.3-x86_64-linux-musl)
     sshkit (1.24.0)
@@ -290,6 +298,7 @@ GEM
     thruster (0.1.15)
     thruster (0.1.15-aarch64-linux)
     thruster (0.1.15-arm64-darwin)
+    thruster (0.1.15-x86_64-darwin)
     thruster (0.1.15-x86_64-linux)
     timeout (0.4.3)
     tzinfo (2.0.6)
@@ -312,6 +321,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin-24
+  x86_64-darwin-24
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl
@@ -320,6 +330,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   debug
+  factory_bot_rails
   kamal
   puma (>= 5.0)
   rails (~> 8.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hana (1.3.7)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)
@@ -117,6 +118,11 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.14.1)
+    json_schemer (2.4.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     kamal (2.7.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -265,6 +271,7 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    simpleidn (0.2.3)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -335,6 +342,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   jbuilder
+  json_schemer
   kamal
   puma (>= 5.0)
   rails (~> 8.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,9 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jbuilder (2.14.1)
+      actionview (>= 7.0.0)
+      activesupport (>= 7.0.0)
     json (2.14.1)
     kamal (2.7.0)
       activesupport (>= 7.0)
@@ -331,6 +334,7 @@ DEPENDENCIES
   brakeman
   debug
   factory_bot_rails
+  jbuilder
   kamal
   puma (>= 5.0)
   rails (~> 8.0.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+
+  private
+
+  def render_not_found(error)
+    render json: { error: error.message }, status: :not_found
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,8 @@ class ApplicationController < ActionController::API
   def render_not_found(error)
     render json: { error: error.message }, status: :not_found
   end
+
+  def render_bad_request(message)
+    render json: { error: message }, status: :bad_request
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+  rescue_from ActionController::ParameterMissing, with: :render_bad_request
 
   private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,4 +11,8 @@ class ApplicationController < ActionController::API
   def render_bad_request(message)
     render json: { error: message }, status: :bad_request
   end
+
+  def render_unprocessable_entity(message)
+    render json: { error: message }, status: :unprocessable_content
+  end
 end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -7,7 +7,7 @@ class AppointmentsController < ApplicationController
     if @appointment.save
       render :show, status: :created
     else
-      render_bad_request(@appointment.errors.full_messages)
+      render_unprocessable_entity(@appointment.errors.full_messages)
     end
   end
 

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -12,9 +12,13 @@ class AppointmentsController < ApplicationController
   end
 
   # DELETE /appointments/:id
-  # Bonus: cancel an appointment instead of deleting
+  # Cancel an appointment instead of deleting
   def destroy
-    raise NotImplementedError, "Implement appointment cancelation endpoint"
+    @appointment = Appointment.find(params[:id])
+
+    @appointment.canceled!
+
+    render :show, status: :ok
   end
 
   private

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -2,12 +2,24 @@ class AppointmentsController < ApplicationController
   # POST /appointments
   # Params: client_id, provider_id, starts_at, ends_at
   def create
-    raise NotImplementedError, "Implement appointment booking endpoint"
+    @appointment = Appointment.new(appointment_params)
+
+    if @appointment.save
+      render :show, status: :created
+    else
+      render_bad_request(@appointment.errors.full_messages)
+    end
   end
 
   # DELETE /appointments/:id
   # Bonus: cancel an appointment instead of deleting
   def destroy
     raise NotImplementedError, "Implement appointment cancelation endpoint"
+  end
+
+  private
+
+  def appointment_params
+    params.require(:appointment).permit(:client_id, :provider_id, :starts_at, :ends_at)
   end
 end

--- a/app/controllers/providers/availabilities_controller.rb
+++ b/app/controllers/providers/availabilities_controller.rb
@@ -1,9 +1,36 @@
 module Providers
   class AvailabilitiesController < ApplicationController
+    before_action :set_provider, only: :index
+    before_action :validate_availability_request, only: :index
+
     # GET /providers/:provider_id/availabilities
     # Expected params: from, to (ISO8601 timestamps)
     def index
-      raise NotImplementedError, "Implement availability search endpoint"
+      result = Providers::Availabilities::FreeSlots.call(
+        provider: @provider,
+        from: @availability_params.from,
+        to: @availability_params.to
+      )
+
+      if result.success?
+        @free_slots = result.data[:free_slots]
+        render :index
+      else
+        render_bad_request(result.error[:error])
+      end
+    end
+
+    private
+
+    def set_provider
+      @provider = Provider.find(params[:provider_id])
+    end
+
+    def validate_availability_request
+      @availability_params = TimeRangeParams.new(params.permit(:from, :to))
+      return if @availability_params.valid?
+
+      render_bad_request(@availability_params.errors.full_messages)
     end
   end
 end

--- a/app/controllers/providers/availabilities_controller.rb
+++ b/app/controllers/providers/availabilities_controller.rb
@@ -16,7 +16,7 @@ module Providers
         @free_slots = result.data[:free_slots]
         render :index
       else
-        render_bad_request(result.error[:error])
+        render_unprocessable_entity(result.error[:error])
       end
     end
 
@@ -29,7 +29,7 @@ module Providers
     def validate_availability_request
       return if availability_params.valid?
 
-      render_bad_request(availability_params.errors.full_messages)
+      render_unprocessable_entity(availability_params.errors.full_messages)
     end
 
     def availability_params

--- a/app/controllers/providers/availabilities_controller.rb
+++ b/app/controllers/providers/availabilities_controller.rb
@@ -8,8 +8,8 @@ module Providers
     def index
       result = Providers::Availabilities::FreeSlots.call(
         provider: @provider,
-        from: @availability_params.from,
-        to: @availability_params.to
+        from: availability_params.from,
+        to: availability_params.to
       )
 
       if result.success?
@@ -27,10 +27,13 @@ module Providers
     end
 
     def validate_availability_request
-      @availability_params = TimeRangeParams.new(params.permit(:from, :to))
-      return if @availability_params.valid?
+      return if availability_params.valid?
 
-      render_bad_request(@availability_params.errors.full_messages)
+      render_bad_request(availability_params.errors.full_messages)
+    end
+
+    def availability_params
+      @availability_params ||= TimeRangeParams.new(params.permit(:from, :to))
     end
   end
 end

--- a/app/forms/time_range_params.rb
+++ b/app/forms/time_range_params.rb
@@ -3,8 +3,8 @@ class TimeRangeParams
   include ActiveModel::Attributes
   include ActiveModel::Validations::Callbacks
 
-  # from is at least "now" (past is not returned for available slots, as they're not available anymore)
-  # to must be strictly after from
+  # `from`` is at least "now" (past is not returned for available slots, as they're not available anymore)
+  # `to` must be strictly after `from`
   attribute :from, :datetime
   attribute :to, :datetime
 

--- a/app/forms/time_range_params.rb
+++ b/app/forms/time_range_params.rb
@@ -11,7 +11,7 @@ class TimeRangeParams
   before_validation :clamp_from_to_now
 
   validates :from, :to, presence: true
-  validates :to, comparison: { greater_than: :from }
+  validates :to, comparison: { greater_than: :from }, if: -> { from.present? && to.present? }
 
   private
 

--- a/app/forms/time_range_params.rb
+++ b/app/forms/time_range_params.rb
@@ -3,10 +3,8 @@ class TimeRangeParams
   include ActiveModel::Attributes
   include ActiveModel::Validations::Callbacks
 
-  # Contract:
-  # - from/to are datetimes
-  # - from is clamped to "now" (past is not returned for available slots, as they're not available anymore)
-  # - to must be in the future and greater than from
+  # from is at least "now" (past is not returned for available slots, as they're not available anymore)
+  # to must be strictly after from
   attribute :from, :datetime
   attribute :to, :datetime
 
@@ -14,7 +12,6 @@ class TimeRangeParams
 
   validates :from, :to, presence: true
   validates :to, comparison: { greater_than: :from }
-  validate :to_must_be_in_future
 
   private
 
@@ -22,11 +19,5 @@ class TimeRangeParams
     return unless from.present?
 
     self.from = [ from, Time.zone.now ].max
-  end
-
-  def to_must_be_in_future
-    return unless to.present?
-
-    errors.add(:to, :greater_than, value: :now) unless to > Time.zone.now
   end
 end

--- a/app/forms/time_range_params.rb
+++ b/app/forms/time_range_params.rb
@@ -1,0 +1,10 @@
+class TimeRangeParams
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :from, :datetime
+  attribute :to, :datetime
+
+  validates :from, :to, presence: true
+  validates :to, comparison: { greater_than: :from }
+end

--- a/app/forms/time_range_params.rb
+++ b/app/forms/time_range_params.rb
@@ -1,10 +1,32 @@
 class TimeRangeParams
   include ActiveModel::Model
   include ActiveModel::Attributes
+  include ActiveModel::Validations::Callbacks
 
+  # Contract:
+  # - from/to are datetimes
+  # - from is clamped to "now" (past is not returned for available slots, as they're not available anymore)
+  # - to must be in the future and greater than from
   attribute :from, :datetime
   attribute :to, :datetime
 
+  before_validation :clamp_from_to_now
+
   validates :from, :to, presence: true
   validates :to, comparison: { greater_than: :from }
+  validate :to_must_be_in_future
+
+  private
+
+  def clamp_from_to_now
+    return unless from.present?
+
+    self.from = [ from, Time.zone.now ].max
+  end
+
+  def to_must_be_in_future
+    return unless to.present?
+
+    errors.add(:to, :greater_than, value: :now) unless to > Time.zone.now
+  end
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,0 +1,12 @@
+class Appointment < ApplicationRecord
+  belongs_to :client
+  belongs_to :provider
+
+  enum :status, {
+    scheduled: "scheduled",
+    canceled: "canceled"
+  }, prefix: true, default: :scheduled, validate: true
+
+  validates :starts_at, :ends_at, :status, presence: true
+  validates :ends_at, comparison: { greater_than: :starts_at, message: "must be after starts_at" }
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -5,8 +5,13 @@ class Appointment < ApplicationRecord
   enum :status, {
     scheduled: "scheduled",
     canceled: "canceled"
-  }, prefix: true, default: :scheduled, validate: true
+  }, default: :scheduled, validate: true
 
   validates :starts_at, :ends_at, :status, presence: true
   validates :ends_at, comparison: { greater_than: :starts_at, message: "must be after starts_at" }
+
+  # Finds appointments that have actual time overlap (touching edges don't count as overlap)
+  scope :overlapping, ->(from_time, to_time) {
+    where("starts_at < ? AND ends_at > ?", to_time, from_time)
+  }
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -10,8 +10,30 @@ class Appointment < ApplicationRecord
   validates :starts_at, :ends_at, :status, presence: true
   validates :ends_at, comparison: { greater_than: :starts_at, message: "must be after starts_at" }
 
+  validate :fits_in_free_slot, if: :time_window_changed?
+
   # Finds appointments that have actual time overlap (touching edges don't count as overlap)
   scope :overlapping, ->(from_time, to_time) {
     where("starts_at < ? AND ends_at > ?", to_time, from_time)
   }
+
+  private
+
+  def time_window_changed?
+    will_save_change_to_starts_at? || will_save_change_to_ends_at?
+  end
+
+  def fits_in_free_slot
+    return if provider.blank? || starts_at.blank? || ends_at.blank?
+
+    # Prevent double-booking under concurrency
+    provider.with_lock do
+      result = Providers::Availabilities::FreeSlots.call(provider:, from: starts_at, to: ends_at)
+
+      free_slots = result.data[:free_slots] if result.success?
+      fits = free_slots.try(:any?) { |slot| slot[:starts_at] <= starts_at && slot[:ends_at] >= ends_at }
+
+      errors.add(:base, "no availability for requested time") unless fits
+    end
+  end
 end

--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -27,4 +27,16 @@ class Availability < ApplicationRecord
   validates :end_time,
             comparison: { greater_than: :start_time, message: "must be after start_time for same-day windows" },
             if: -> { start_day_of_week == end_day_of_week }
+
+  def start_dow
+    self.class.start_day_of_weeks[start_day_of_week]
+  end
+
+  def end_dow
+    self.class.end_day_of_weeks[end_day_of_week]
+  end
+
+  def days_until_end
+    (end_dow - start_dow) % 7
+  end
 end

--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -1,0 +1,30 @@
+class Availability < ApplicationRecord
+  belongs_to :provider
+
+  DAYS_OF_WEEK = {
+    sunday: 0,
+    monday: 1,
+    tuesday: 2,
+    wednesday: 3,
+    thursday: 4,
+    friday: 5,
+    saturday: 6
+  }.freeze
+
+  enum :start_day_of_week, DAYS_OF_WEEK, prefix: :starts_on, validate: true
+  enum :end_day_of_week, DAYS_OF_WEEK, prefix: :ends_on, validate: true
+
+  validates :source,
+            :external_id,
+            :start_day_of_week,
+            :end_day_of_week,
+            :start_time,
+            :end_time,
+            presence: true
+
+  validates :external_id, uniqueness: { scope: %i[provider_id source] }
+
+  validates :end_time,
+            comparison: { greater_than: :start_time, message: "must be after start_time for same-day windows" },
+            if: -> { start_day_of_week == end_day_of_week }
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,0 +1,3 @@
+class Client < ApplicationRecord
+  has_many :appointments
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,3 +1,3 @@
 class Client < ApplicationRecord
-  has_many :appointments
+  has_many :appointments, dependent: :restrict_with_error
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,0 +1,4 @@
+class Provider < ApplicationRecord
+  has_many :availabilities
+  has_many :appointments
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,4 +1,4 @@
 class Provider < ApplicationRecord
-  has_many :availabilities
-  has_many :appointments
+  has_many :availabilities, dependent: :restrict_with_error
+  has_many :appointments, dependent: :restrict_with_error
 end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,22 @@
+require "ostruct"
+
+class ApplicationService
+  def self.call(*args, **kwargs, &block)
+    new(*args, **kwargs).call(&block)
+  end
+
+  def call
+    # To be implemented by child classes
+    raise NotImplementedError, "#{self.class}#call is not implemented"
+  end
+
+  private
+
+  def success(data = {})
+    OpenStruct.new(success?: true, data:, error: nil)
+  end
+
+  def failure(error)
+    OpenStruct.new(success?: false, data: nil, error:)
+  end
+end

--- a/app/services/availability_sync.rb
+++ b/app/services/availability_sync.rb
@@ -1,4 +1,5 @@
-# In production/live code, this service could be called from a webhook controller
+# In production/live code, trigger this via a webhook → background job.
+# Optionally prune: delete provider Calendly availabilities whose external_ids are absent in the payload.
 
 class AvailabilitySync < ApplicationService
   def initialize(client: CalendlyClient.new, provider_id:)

--- a/app/services/availability_sync.rb
+++ b/app/services/availability_sync.rb
@@ -1,3 +1,5 @@
+# In production/live code, this service could be called from a webhook controller
+
 class AvailabilitySync < ApplicationService
   def initialize(client: CalendlyClient.new, provider_id:)
     @client = client

--- a/app/services/availability_sync.rb
+++ b/app/services/availability_sync.rb
@@ -1,15 +1,59 @@
-class AvailabilitySync
-  def initialize(client: CalendlyClient.new)
+class AvailabilitySync < ApplicationService
+  def initialize(client: CalendlyClient.new, provider_id:)
     @client = client
+    @provider_id = provider_id
   end
 
   # Syncs availabilities for a provider based on the Calendly feed.
   # Candidates should fetch slots from the CalendlyClient and upsert Availability records.
-  def call(provider_id:)
-    raise NotImplementedError, "Implement availability sync logic"
+  def call
+    counts = { created: 0, updated: 0, unchanged: 0, total: 0 }
+    errors = []
+
+    client.fetch_slots(provider_id).each do |slot|
+      counts[:total] += 1
+
+      availability = availability_from_slot(slot)
+
+      new_record = availability.new_record?
+      unless new_record || availability.changed?
+        counts[:unchanged] += 1
+        next
+      end
+
+      if availability.save
+        new_record ? counts[:created] += 1 : counts[:updated] += 1
+      else
+        errors << { external_id: slot["id"], messages: availability.errors.full_messages }
+      end
+    end
+
+    return failure(message: "Some availabilities failed to sync", counts:, errors:) if errors.any?
+
+    success(counts:)
   end
 
   private
 
-  attr_reader :client
+  attr_reader :client, :provider_id
+
+  def availability_from_slot(slot)
+    starts = slot["starts_at"]
+    ends = slot["ends_at"]
+
+    availability = Availability.find_or_initialize_by(
+      provider_id:,
+      source: slot["source"],
+      external_id: slot["id"]
+    )
+
+    availability.assign_attributes(
+      start_day_of_week: starts["day_of_week"],
+      end_day_of_week: ends["day_of_week"],
+      start_time: starts["time"],
+      end_time: ends["time"]
+    )
+
+    availability
+  end
 end

--- a/app/services/providers/availabilities/date_helpers.rb
+++ b/app/services/providers/availabilities/date_helpers.rb
@@ -1,0 +1,10 @@
+module Providers
+  module Availabilities
+    module DateHelpers
+      # Include previous day to capture overnight windows
+      def dates_in_scope(from:, to:)
+        (from.to_date - 1).upto(to.to_date)
+      end
+    end
+  end
+end

--- a/app/services/providers/availabilities/free_slots.rb
+++ b/app/services/providers/availabilities/free_slots.rb
@@ -1,9 +1,5 @@
-# This service is responsible for the business logic of building truly free slot windows for a provider
-# in a given time range. It takes recurring availabilities (from Query), expands them into concrete
-# date/time intervals, clamps them to the requested range, and subtracts out any overlapping appointments.
-# This separation of concerns keeps the query logic efficient and focused, while allowing all business
-# rules and edge cases to be handled in one place. This approach is idiomatic Rails, supports maintainability,
-# and directly maps to the challenge requirements: the API returns only truly free, bookable slots.
+# Expands recurring provider availabilities into concrete, bookable time slots within a given range.
+# Subtracts scheduled appointments and merges adjacent intervals.
 
 module Providers
   module Availabilities

--- a/app/services/providers/availabilities/free_slots.rb
+++ b/app/services/providers/availabilities/free_slots.rb
@@ -1,0 +1,148 @@
+# This service is responsible for the business logic of building truly free slot windows for a provider
+# in a given time range. It takes recurring availabilities (from Query), expands them into concrete
+# date/time intervals, clamps them to the requested range, and subtracts out any overlapping appointments.
+# This separation of concerns keeps the query logic efficient and focused, while allowing all business
+# rules and edge cases to be handled in one place. This approach is idiomatic Rails, supports maintainability,
+# and directly maps to the challenge requirements: the API returns only truly free, bookable slots.
+
+module Providers
+  module Availabilities
+    class FreeSlots < ApplicationService
+      include DateHelpers
+
+      def initialize(provider:, from:, to:)
+        @provider = provider
+        @from = from
+        @to = to
+      end
+
+      def call
+        # Query for all availabilities that could possibly overlap the range
+        query = Query.call(provider:, from:, to:)
+        return failure(error: "availability lookup failed") unless query.success?
+
+        availabilities = query.data[:availabilities]
+        # Expand recurring availabilities into concrete windows for each date
+        occurrences = expand_occurrences(availabilities)
+        # Clamp each window to the requested range (so we never return more than asked)
+        clamped = clamp_occurrences(occurrences)
+        # Remove zero-length intervals (can happen after clamping, e.g. slot ends exactly at the query start)
+        clamped = clamped.reject { |occurrence| occurrence[:starts_at] == occurrence[:ends_at] }
+        # Find all scheduled appointments that overlap the requested range
+        busy = provider.appointments.scheduled.overlapping(from, to)
+        # Subtract busy times from available windows to get truly free slots
+        unmerged_free_slots = subtract_appointments(occurrences: clamped, appointments: busy)
+        free_slots = merge_intervals(unmerged_free_slots)
+
+        success(free_slots:)
+      end
+
+      private
+
+      attr_reader :provider, :from, :to
+
+      # For each date, expand availabilities into concrete time windows
+      # Handles recurring weekly slots and overnight/multi-day windows
+      def expand_occurrences(availabilities)
+        dates_in_scope(from:, to:).flat_map do |date|
+          availabilities.select { |a| date.wday == a.start_dow }.filter_map do |availability|
+            window_start = at_time_on(date: date, time_of_day: availability.start_time)
+            window_end = at_time_on(date: date + availability.days_until_end, time_of_day: availability.end_time)
+            # Only include windows that actually overlap the requested range
+            next if window_end <= from || window_start >= to
+
+            { starts_at: window_start, ends_at: window_end }
+          end
+        end
+      end
+
+      # Clamp each occurrence to the requested range, so we only return the part that's actually available
+      # (if a slot is 09:00-11:00 and you ask for 10:00-12:00, you get 10:00-11:00)
+      def clamp_occurrences(occurrences)
+        occurrences.map do |occurrence|
+          {
+            starts_at: [ occurrence[:starts_at], from ].max,
+            ends_at: [ occurrence[:ends_at], to ].min
+          }
+        end
+      end
+
+      # Subtract out all busy times (appointments) from the available windows
+      # This is the heart of "free slot" logic: split windows around appointments
+      def subtract_appointments(occurrences:, appointments:)
+        occurrences.flat_map do |occurrence|
+          subtract_from_interval(occurrence:, appointments:)
+        end
+      end
+
+      # For a single window, split it into free periods around any overlapping appointments
+      # Handles multiple overlapping appointments and edge cases (e.g. back-to-back bookings)
+      def subtract_from_interval(occurrence:, appointments:)
+        interval_start = occurrence[:starts_at]
+        interval_end = occurrence[:ends_at]
+
+        # Find all appointments that overlap this window
+        overlapping = appointments.select do |appointment|
+          appointment.starts_at < interval_end && appointment.ends_at > interval_start
+        end
+        # If no overlaps, the whole window is free
+        if overlapping.empty?
+          return [ build_interval(starts_at: interval_start, ends_at: interval_end) ]
+        end
+
+        free_periods = []
+        current_start = interval_start
+
+        # Sort appointments by start time to process in order
+        overlapping.sort_by(&:starts_at).each do |appointment|
+          busy_start = [ appointment.starts_at, interval_start ].max
+          busy_end = [ appointment.ends_at, interval_end ].min
+
+          # Add free period before this appointment, if any
+          if current_start < busy_start
+            free_periods << build_interval(starts_at: current_start, ends_at: busy_start)
+          end
+
+          # Move current_start past this appointment
+          current_start = [ current_start, busy_end ].max
+        end
+
+        # Add any remaining free period after the last appointment
+        if current_start < interval_end
+          free_periods << build_interval(starts_at: current_start, ends_at: interval_end)
+        end
+        free_periods
+      end
+
+      # Merge contiguous or overlapping intervals to produce a normalized set
+      def merge_intervals(intervals)
+        return intervals if intervals.empty?
+
+        sorted = intervals.sort_by { |i| [ i[:starts_at], i[:ends_at] ] }
+        merged = [ sorted.first.dup ]
+
+        sorted.drop(1).each do |curr|
+          last = merged.last
+          if curr[:starts_at] <= last[:ends_at]
+            # overlap or touch: extend
+            last[:ends_at] = [ last[:ends_at], curr[:ends_at] ].max
+          else
+            merged << curr.dup
+          end
+        end
+        merged
+      end
+
+      # Returns a hash with only starts_at and ends_at; formatting is left to the view layer
+      def build_interval(starts_at:, ends_at:)
+        { starts_at:, ends_at: }
+      end
+
+      # Combine a date and a time-of-day into a Time object in the app's timezone
+      # This is needed because availabilities are stored as day-of-week + time-of-day
+      def at_time_on(date:, time_of_day:)
+        Time.zone.local(date.year, date.month, date.day, time_of_day.hour, time_of_day.min, time_of_day.sec)
+      end
+    end
+  end
+end

--- a/app/services/providers/availabilities/query.rb
+++ b/app/services/providers/availabilities/query.rb
@@ -1,0 +1,64 @@
+# This service is responsible solely for efficiently fetching recurring availabilities for a provider
+# that could possibly overlap a given time range. It does not expand these into concrete date/time windows;
+# that responsibility is delegated to downstream business logic (e.g., FreeSlots).
+# This separation of concerns keeps the query logic efficient, testable, and focused, and allows
+# business rules (like clamping, splitting, and subtracting appointments) to evolve independently.
+# This approach is idiomatic Rails, supports maintainability, and directly maps to the challenge requirements:
+# - Query: fetch relevant availabilities
+# - FreeSlots: build actual free slot windows, subtracting appointments, and clamping to the requested range.
+
+module Providers
+  module Availabilities
+    class Query < ApplicationService
+      include DateHelpers
+
+      def initialize(provider:, from:, to:)
+        @provider = provider
+        @from = from
+        @to = to
+      end
+
+      def call
+        availabilities = availabilities_for_days.select { |availability| overlaps_range?(availability) }
+        success(availabilities:)
+      end
+
+      private
+
+      attr_reader :provider, :from, :to
+
+      # Fetches availabilities that could possibly overlap the range, by day
+      def availabilities_for_days
+        provider.availabilities.where(
+          "start_day_of_week IN (?) OR end_day_of_week IN (?)",
+          days_in_scope,
+          days_in_scope
+        )
+      end
+
+      # All unique weekdays in the date range (including the day before, for overnight slots)
+      def days_in_scope
+        dates_in_scope(from:, to:).map(&:wday).uniq
+      end
+
+      # Checks if any instance of this availability overlaps the requested time window
+      def overlaps_range?(availability)
+        dates_in_scope(from:, to:).any? do |date|
+          # Only consider windows that start on this date
+          next unless date.wday == availability.start_dow
+
+          window_start = at_time_on(date, availability.start_time)
+          window_end = at_time_on(date + availability.days_until_end, availability.end_time)
+
+          # Classic interval overlap: does this window intersect the requested range?
+          window_start < to && window_end > from
+        end
+      end
+
+      # Combines a date and a time-of-day into a Time object in the app's timezone
+      def at_time_on(date, time_of_day)
+        Time.zone.local(date.year, date.month, date.day, time_of_day.hour, time_of_day.min, time_of_day.sec)
+      end
+    end
+  end
+end

--- a/app/services/providers/availabilities/query.rb
+++ b/app/services/providers/availabilities/query.rb
@@ -1,11 +1,5 @@
-# This service is responsible solely for efficiently fetching recurring availabilities for a provider
-# that could possibly overlap a given time range. It does not expand these into concrete date/time windows;
-# that responsibility is delegated to downstream business logic (e.g., FreeSlots).
-# This separation of concerns keeps the query logic efficient, testable, and focused, and allows
-# business rules (like clamping, splitting, and subtracting appointments) to evolve independently.
-# This approach is idiomatic Rails, supports maintainability, and directly maps to the challenge requirements:
-# - Query: fetch relevant availabilities
-# - FreeSlots: build actual free slot windows, subtracting appointments, and clamping to the requested range.
+# Selects recurring provider availabilities that could overlap a given time range.
+# Filters only relevant weekly windows; does not expand to concrete times or subtract appointments.
 
 module Providers
   module Availabilities

--- a/app/views/appointments/show.json.jbuilder
+++ b/app/views/appointments/show.json.jbuilder
@@ -1,7 +1,5 @@
-json.id @appointment.id
-json.client_id @appointment.client_id
-json.provider_id @appointment.provider_id
-json.status @appointment.status
+json.extract! @appointment, :id, :client_id, :provider_id, :status
+
 json.starts_at @appointment.starts_at.iso8601
 json.ends_at @appointment.ends_at.iso8601
 json.created_at @appointment.created_at.iso8601

--- a/app/views/appointments/show.json.jbuilder
+++ b/app/views/appointments/show.json.jbuilder
@@ -1,0 +1,8 @@
+json.id @appointment.id
+json.client_id @appointment.client_id
+json.provider_id @appointment.provider_id
+json.status @appointment.status
+json.starts_at @appointment.starts_at.iso8601
+json.ends_at @appointment.ends_at.iso8601
+json.created_at @appointment.created_at.iso8601
+json.updated_at @appointment.updated_at.iso8601

--- a/app/views/providers/availabilities/index.json.jbuilder
+++ b/app/views/providers/availabilities/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.provider_id @provider.id
+json.from @availability_params.from.iso8601
+json.to @availability_params.to.iso8601
+
+json.free_slots @free_slots do |slot|
+  json.starts_at slot[:starts_at].iso8601
+  json.ends_at slot[:ends_at].iso8601
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,15 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+  scope defaults: { format: :json } do
+    # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+    # Can be used by load balancers and uptime monitors to verify that the app is live.
+    get "up" => "rails/health#show", as: :rails_health_check
 
-  resources :providers, only: [] do
-    resources :availabilities, only: :index, module: :providers
+    resources :providers, only: [] do
+      resources :availabilities, only: :index, module: :providers
+    end
+
+    resources :appointments, only: %i[create destroy]
   end
-
-  resources :appointments, only: %i[create destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  scope defaults: { format: :json } do
-    # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-    # Can be used by load balancers and uptime monitors to verify that the app is live.
-    get "up" => "rails/health#show", as: :rails_health_check
+  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  get "up" => "rails/health#show", as: :rails_health_check
 
+  scope defaults: { format: :json } do
     resources :providers, only: [] do
       resources :availabilities, only: :index, module: :providers
     end

--- a/db/migrate/20250922154111_create_providers.rb
+++ b/db/migrate/20250922154111_create_providers.rb
@@ -1,0 +1,7 @@
+class CreateProviders < ActiveRecord::Migration[8.0]
+  def change
+    create_table :providers do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250922154223_create_clients.rb
+++ b/db/migrate/20250922154223_create_clients.rb
@@ -1,0 +1,7 @@
+class CreateClients < ActiveRecord::Migration[8.0]
+  def change
+    create_table :clients do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250922160222_create_availabilities.rb
+++ b/db/migrate/20250922160222_create_availabilities.rb
@@ -1,0 +1,19 @@
+class CreateAvailabilities < ActiveRecord::Migration[8.0]
+  def change
+    create_table :availabilities do |t|
+      t.references :provider, null: false, foreign_key: true
+      t.string :source, null: false
+      t.string :external_id, null: false
+      t.integer :start_day_of_week, null: false
+      t.time :start_time, null: false
+      t.integer :end_day_of_week, null: false
+      t.time :end_time, null: false
+
+      t.timestamps
+    end
+
+    add_index :availabilities, [ :provider_id, :source, :external_id ], unique: true, name: "index_availabilities_on_provider_source_external_id"
+    add_check_constraint :availabilities, "start_day_of_week BETWEEN 0 AND 6", name: "check_availabilities_start_day_of_week_range"
+    add_check_constraint :availabilities, "end_day_of_week BETWEEN 0 AND 6", name: "check_availabilities_end_day_of_week_range"
+  end
+end

--- a/db/migrate/20250922160607_create_appointments.rb
+++ b/db/migrate/20250922160607_create_appointments.rb
@@ -1,0 +1,15 @@
+class CreateAppointments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :appointments do |t|
+      t.references :client, null: false, foreign_key: true
+      t.references :provider, null: false, foreign_key: true
+      t.datetime :starts_at, null: false
+      t.datetime :ends_at, null: false
+      t.string :status, null: false, default: "scheduled"
+
+      t.timestamps
+    end
+
+    add_check_constraint :appointments, "ends_at > starts_at", name: "check_appointments_ends_after_starts"
+  end
+end

--- a/db/migrate/20250923043213_add_indexes_to_availabilities_and_appointments.rb
+++ b/db/migrate/20250923043213_add_indexes_to_availabilities_and_appointments.rb
@@ -1,0 +1,9 @@
+class AddIndexesToAvailabilitiesAndAppointments < ActiveRecord::Migration[8.0]
+  def change
+    add_index :availabilities, [:provider_id, :start_day_of_week], name: "index_availabilities_on_provider_and_start_dow"
+    add_index :availabilities, [:provider_id, :end_day_of_week], name: "index_availabilities_on_provider_and_end_dow"
+
+    add_index :appointments, [:provider_id, :starts_at], name: "index_appointments_on_provider_and_starts_at"
+    add_index :appointments, [:provider_id, :ends_at], name: "index_appointments_on_provider_and_ends_at"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,56 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_09_22_160607) do
+  create_table "appointments", force: :cascade do |t|
+    t.integer "client_id", null: false
+    t.integer "provider_id", null: false
+    t.datetime "starts_at", null: false
+    t.datetime "ends_at", null: false
+    t.string "status", default: "scheduled", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["client_id"], name: "index_appointments_on_client_id"
+    t.index ["provider_id"], name: "index_appointments_on_provider_id"
+    t.check_constraint "ends_at > starts_at", name: "check_appointments_ends_after_starts"
+  end
+
+  create_table "availabilities", force: :cascade do |t|
+    t.integer "provider_id", null: false
+    t.string "source", null: false
+    t.string "external_id", null: false
+    t.integer "start_day_of_week", null: false
+    t.time "start_time", null: false
+    t.integer "end_day_of_week", null: false
+    t.time "end_time", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider_id", "source", "external_id"], name: "index_availabilities_on_provider_source_external_id", unique: true
+    t.index ["provider_id"], name: "index_availabilities_on_provider_id"
+    t.check_constraint "end_day_of_week BETWEEN 0 AND 6", name: "check_availabilities_end_day_of_week_range"
+    t.check_constraint "start_day_of_week BETWEEN 0 AND 6", name: "check_availabilities_start_day_of_week_range"
+  end
+
+  create_table "clients", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "providers", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "appointments", "clients"
+  add_foreign_key "appointments", "providers"
+  add_foreign_key "availabilities", "providers"
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_22_160607) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_23_043213) do
   create_table "appointments", force: :cascade do |t|
     t.integer "client_id", null: false
     t.integer "provider_id", null: false
@@ -20,6 +20,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_22_160607) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["client_id"], name: "index_appointments_on_client_id"
+    t.index ["provider_id", "ends_at"], name: "index_appointments_on_provider_and_ends_at"
+    t.index ["provider_id", "starts_at"], name: "index_appointments_on_provider_and_starts_at"
     t.index ["provider_id"], name: "index_appointments_on_provider_id"
     t.check_constraint "ends_at > starts_at", name: "check_appointments_ends_after_starts"
   end
@@ -34,7 +36,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_22_160607) do
     t.time "end_time", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["provider_id", "end_day_of_week"], name: "index_availabilities_on_provider_and_end_dow"
     t.index ["provider_id", "source", "external_id"], name: "index_availabilities_on_provider_source_external_id", unique: true
+    t.index ["provider_id", "start_day_of_week"], name: "index_availabilities_on_provider_and_start_dow"
     t.index ["provider_id"], name: "index_availabilities_on_provider_id"
     t.check_constraint "end_day_of_week BETWEEN 0 AND 6", name: "check_availabilities_end_day_of_week_range"
     t.check_constraint "start_day_of_week BETWEEN 0 AND 6", name: "check_availabilities_start_day_of_week_range"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@
 # We intentionally do not seed Availability or Appointment here.
 # - Availability is synchronized from Calendly's fixture via AvailabilitySync.
 # - Appointments are created via the POST /appointments endpoint.
-# Seed only core entities that lack external sync/endpoints (e.g., Provider, Client).
+# Seed only core entities that lack external sync/endpoints
 
 3.times { |n| Provider.find_or_create_by!(id: n + 1) }
 5.times { |n| Client.find_or_create_by!(id: n + 1) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,35 +1,8 @@
-provider1 = Provider.find_or_create_by!(id: 1)
-provider2 = Provider.find_or_create_by!(id: 2)
+# Note:
+# We intentionally do not seed Availability or Appointment here.
+# - Availability is synchronized from Calendly's fixture via AvailabilitySync.
+# - Appointments are created via the POST /appointments endpoint.
+# Seed only core entities that lack external sync/endpoints (e.g., Provider, Client).
 
-client1 = Client.find_or_create_by!(id: 1)
-client2 = Client.find_or_create_by!(id: 2)
-
-Availability.find_or_create_by!(provider: provider1, source: "calendly", external_id: "p1-slot-early-morning") do |a|
-  a.start_day_of_week = :monday
-  a.start_time = "08:00"
-  a.end_day_of_week = :monday
-  a.end_time = "09:30"
-end
-
-Availability.find_or_create_by!(provider: provider2, source: "calendly", external_id: "p2-slot-short") do |a|
-  a.start_day_of_week = :tuesday
-  a.start_time = "14:00"
-  a.end_day_of_week = :tuesday
-  a.end_time = "15:30"
-end
-
-Appointment.find_or_create_by!(
-  client: client1,
-  provider: provider1,
-  starts_at: "2025-09-29 09:00",
-  ends_at: "2025-09-29 09:30",
-  status: :scheduled
-)
-
-Appointment.find_or_create_by!(
-  client: client2,
-  provider: provider2,
-  starts_at: "2025-09-30 14:15",
-  ends_at: "2025-09-30 14:45",
-  status: :scheduled
-)
+3.times { |n| Provider.find_or_create_by!(id: n + 1) }
+5.times { |n| Client.find_or_create_by!(id: n + 1) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,35 @@
-# Seed data is intentionally left blank.
-# Candidates can add sample clients/providers/availabilities once their schema is in place.
+provider1 = Provider.find_or_create_by!(id: 1)
+provider2 = Provider.find_or_create_by!(id: 2)
+
+client1 = Client.find_or_create_by!(id: 1)
+client2 = Client.find_or_create_by!(id: 2)
+
+Availability.find_or_create_by!(provider: provider1, source: "calendly", external_id: "p1-slot-early-morning") do |a|
+  a.start_day_of_week = :monday
+  a.start_time = "08:00"
+  a.end_day_of_week = :monday
+  a.end_time = "09:30"
+end
+
+Availability.find_or_create_by!(provider: provider2, source: "calendly", external_id: "p2-slot-short") do |a|
+  a.start_day_of_week = :tuesday
+  a.start_time = "14:00"
+  a.end_day_of_week = :tuesday
+  a.end_time = "15:30"
+end
+
+Appointment.find_or_create_by!(
+  client: client1,
+  provider: provider1,
+  starts_at: "2025-09-29 09:00",
+  ends_at: "2025-09-29 09:30",
+  status: :scheduled
+)
+
+Appointment.find_or_create_by!(
+  client: client2,
+  provider: provider2,
+  starts_at: "2025-09-30 14:15",
+  ends_at: "2025-09-30 14:45",
+  status: :scheduled
+)

--- a/test/controllers/appointments_controller_test.rb
+++ b/test/controllers/appointments_controller_test.rb
@@ -16,6 +16,7 @@ class AppointmentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
 
     body = JSON.parse(@response.body)
+    assert_schema "appointments_show.json", body
     assert_equal @client.id, body["client_id"]
     assert_equal @provider.id, body["provider_id"]
     assert_equal starts_at.iso8601, body["starts_at"]

--- a/test/controllers/appointments_controller_test.rb
+++ b/test/controllers/appointments_controller_test.rb
@@ -52,4 +52,25 @@ class AppointmentsControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(@response.body)
     assert body["error"].present?
   end
+
+  test "DELETE /appointments/:id soft-cancels and returns updated resource" do
+    monday = Time.zone.now.next_week(:monday)
+    appt = create(:appointment, client: @client, provider: @provider, starts_at: monday.change(hour: 9, min: 0), ends_at: monday.change(hour: 9, min: 30))
+
+    delete appointment_path(appt)
+    assert_response :ok
+
+    body = JSON.parse(@response.body)
+    assert_schema "appointments_show.json", body
+    assert_equal "canceled", body["status"]
+    assert_equal appt.id, body["id"]
+  end
+
+  test "DELETE /appointments/:id returns 404 when not found" do
+    delete appointment_path(999_999)
+    assert_response :not_found
+
+    body = JSON.parse(@response.body)
+    assert body["error"].present?
+  end
 end

--- a/test/controllers/appointments_controller_test.rb
+++ b/test/controllers/appointments_controller_test.rb
@@ -1,11 +1,54 @@
 require "test_helper"
 
 class AppointmentsControllerTest < ActionDispatch::IntegrationTest
-  test "POST /appointments creates an appointment" do
-    skip "Implement request spec once endpoint is built"
+  setup do
+    @provider = create(:provider, id: 1)
+    @client = create(:client)
+    AvailabilitySync.call(provider_id: @provider.id)
   end
 
-  test "DELETE /appointments/:id cancels an appointment" do
-    skip "Implement request spec once endpoint is built"
+  test "POST /appointments creates when inside free slot" do
+    monday = Time.zone.now.next_week(:monday)
+    starts_at = monday.change(hour: 9, min: 5)
+    ends_at= monday.change(hour: 9, min: 25)
+
+    post appointments_path, params: { appointment: { client_id: @client.id, provider_id: @provider.id, starts_at:, ends_at: } }
+    assert_response :created
+
+    body = JSON.parse(@response.body)
+    assert_equal @client.id, body["client_id"]
+    assert_equal @provider.id, body["provider_id"]
+    assert_equal starts_at.iso8601, body["starts_at"]
+    assert_equal ends_at.iso8601, body["ends_at"]
+    assert_equal "scheduled", body["status"]
+  end
+
+  test "POST /appointments returns 400 for invalid time range" do
+    post appointments_path, params: { appointment: { client_id: @client.id, provider_id: @provider.id, starts_at: nil, ends_at: nil } }
+    assert_response :bad_request
+
+    body = JSON.parse(@response.body)
+    assert body["error"].present?
+  end
+
+  test "POST /appointments returns 400 when appointment param missing" do
+    post appointments_path, params: {}
+    assert_response :bad_request
+
+    body = JSON.parse(@response.body)
+    assert_match /param is missing/, body["error"].to_s
+  end
+
+  test "POST /appointments returns 400 for conflict" do
+    monday = Time.zone.now.next_week(:monday)
+    # Existing appointment inside the 9:00-9:30 slot
+    create(:appointment, client: @client, provider: @provider, starts_at: monday.change(hour: 9, min: 10), ends_at: monday.change(hour: 9, min: 20))
+
+    # Try to book overlapping window
+    post appointments_path, params: { appointment: { client_id: @client.id, provider_id: @provider.id, starts_at: monday.change(hour: 9, min: 0), ends_at: monday.change(hour: 9, min: 30) } }
+    assert_response :bad_request
+
+    body = JSON.parse(@response.body)
+    assert body["error"].present?
   end
 end

--- a/test/controllers/providers/availabilities_controller_test.rb
+++ b/test/controllers/providers/availabilities_controller_test.rb
@@ -28,9 +28,9 @@ class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
     assert_includes slots, expect3
   end
 
-  test "GET returns 400 for invalid params" do
+  test "GET returns 422 for invalid params" do
     get provider_availabilities_path(@provider), params: { from: nil, to: nil }
-    assert_response :bad_request
+    assert_response :unprocessable_content
 
     body = JSON.parse(@response.body)
     assert body["error"].present?

--- a/test/controllers/providers/availabilities_controller_test.rb
+++ b/test/controllers/providers/availabilities_controller_test.rb
@@ -3,12 +3,12 @@ class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @provider = create(:provider, id: 1)
     AvailabilitySync.call(provider_id: @provider.id)
+    @monday = Time.zone.now.next_week(:monday)
   end
 
   test "GET /providers/:provider_id/availabilities returns free slots (happy path)" do
-    base_monday = Time.zone.now.next_week(:monday)
-    from_time = base_monday.change(hour: 9, min: 0)
-    to_time = base_monday.change(hour: 12, min: 0)
+    from_time = @monday.change(hour: 9, min: 0)
+    to_time = @monday.change(hour: 12, min: 0)
 
     get provider_availabilities_path(@provider), params: { from: from_time.iso8601, to: to_time.iso8601 }
     assert_response :success
@@ -21,9 +21,9 @@ class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
 
     slots = body["free_slots"]
 
-    expect1 = { "starts_at" => base_monday.change(hour: 9,  min: 0).iso8601,  "ends_at" => base_monday.change(hour: 9,  min: 30).iso8601 }
-    expect2 = { "starts_at" => base_monday.change(hour: 9,  min: 45).iso8601, "ends_at" => base_monday.change(hour: 10, min: 15).iso8601 }
-    expect3 = { "starts_at" => base_monday.change(hour: 11, min: 30).iso8601, "ends_at" => base_monday.change(hour: 12, min: 0).iso8601 }
+    expect1 = { "starts_at" => @monday.change(hour: 9,  min: 0).iso8601,  "ends_at" => @monday.change(hour: 9,  min: 30).iso8601 }
+    expect2 = { "starts_at" => @monday.change(hour: 9,  min: 45).iso8601, "ends_at" => @monday.change(hour: 10, min: 15).iso8601 }
+    expect3 = { "starts_at" => @monday.change(hour: 11, min: 30).iso8601, "ends_at" => @monday.change(hour: 12, min: 0).iso8601 }
 
     assert_includes slots, expect1
     assert_includes slots, expect2
@@ -47,9 +47,8 @@ class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "GET excludes slots that end exactly at from (no touch-only)" do
-    base_monday = Time.zone.now.next_week(:monday)
-    from_time = base_monday.change(hour: 10, min: 15) # ends_at of 09:45-10:15
-    to_time = base_monday.change(hour: 10, min: 30)
+    from_time = @monday.change(hour: 10, min: 15) # ends_at of 09:45-10:15
+    to_time = @monday.change(hour: 10, min: 30)
 
     get provider_availabilities_path(@provider), params: { from: from_time.iso8601, to: to_time.iso8601 }
     assert_response :success
@@ -60,9 +59,8 @@ class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "GET excludes slots that start exactly at to (no touch-only)" do
-    base_monday = Time.zone.now.next_week(:monday)
-    from_time = base_monday.change(hour: 8,  min: 30)
-    to_time = base_monday.change(hour: 9,  min: 0) # starts_at of 09:00-09:30
+    from_time = @monday.change(hour: 8,  min: 30)
+    to_time = @monday.change(hour: 9,  min: 0) # starts_at of 09:00-09:30
 
     get provider_availabilities_path(@provider), params: { from: from_time.iso8601, to: to_time.iso8601 }
     assert_response :success

--- a/test/controllers/providers/availabilities_controller_test.rb
+++ b/test/controllers/providers/availabilities_controller_test.rb
@@ -15,6 +15,7 @@ class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     body = JSON.parse(@response.body)
+    assert_schema "providers_availabilities_index.json", body
     assert_equal @provider.id, body["provider_id"]
     assert_equal from_time.iso8601, body["from"]
     assert_equal to_time.iso8601, body["to"]

--- a/test/controllers/providers/availabilities_controller_test.rb
+++ b/test/controllers/providers/availabilities_controller_test.rb
@@ -8,9 +8,9 @@ class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
   test "GET /providers/:provider_id/availabilities returns free slots (happy path)" do
     base_monday = Time.zone.now.next_week(:monday)
     from_time = base_monday.change(hour: 9, min: 0)
-    to_time   = base_monday.change(hour: 12, min: 0)
+    to_time = base_monday.change(hour: 12, min: 0)
 
-    get provider_availabilities_path(@provider), params: { from: from_time.strftime("%Y-%m-%d %H:%M"), to: to_time.strftime("%Y-%m-%d %H:%M") }
+    get provider_availabilities_path(@provider), params: { from: from_time.iso8601, to: to_time.iso8601 }
     assert_response :success
 
     body = JSON.parse(@response.body)
@@ -20,9 +20,11 @@ class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
     assert_equal to_time.iso8601, body["to"]
 
     slots = body["free_slots"]
+
     expect1 = { "starts_at" => base_monday.change(hour: 9,  min: 0).iso8601,  "ends_at" => base_monday.change(hour: 9,  min: 30).iso8601 }
     expect2 = { "starts_at" => base_monday.change(hour: 9,  min: 45).iso8601, "ends_at" => base_monday.change(hour: 10, min: 15).iso8601 }
     expect3 = { "starts_at" => base_monday.change(hour: 11, min: 30).iso8601, "ends_at" => base_monday.change(hour: 12, min: 0).iso8601 }
+
     assert_includes slots, expect1
     assert_includes slots, expect2
     assert_includes slots, expect3
@@ -49,7 +51,7 @@ class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
     from_time = base_monday.change(hour: 10, min: 15) # ends_at of 09:45-10:15
     to_time = base_monday.change(hour: 10, min: 30)
 
-    get provider_availabilities_path(@provider), params: { from: from_time.strftime("%Y-%m-%d %H:%M"), to: to_time.strftime("%Y-%m-%d %H:%M") }
+    get provider_availabilities_path(@provider), params: { from: from_time.iso8601, to: to_time.iso8601 }
     assert_response :success
 
     body = JSON.parse(@response.body)
@@ -62,7 +64,7 @@ class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
     from_time = base_monday.change(hour: 8,  min: 30)
     to_time = base_monday.change(hour: 9,  min: 0) # starts_at of 09:00-09:30
 
-    get provider_availabilities_path(@provider), params: { from: from_time.strftime("%Y-%m-%d %H:%M"), to: to_time.strftime("%Y-%m-%d %H:%M") }
+    get provider_availabilities_path(@provider), params: { from: from_time.iso8601, to: to_time.iso8601 }
     assert_response :success
 
     body = JSON.parse(@response.body)

--- a/test/controllers/providers/availabilities_controller_test.rb
+++ b/test/controllers/providers/availabilities_controller_test.rb
@@ -1,7 +1,46 @@
 require "test_helper"
 
 class Providers::AvailabilitiesControllerTest < ActionDispatch::IntegrationTest
-  test "GET /providers/:provider_id/availabilities returns availabilities" do
-    skip "Implement request spec once endpoint is built"
+  setup do
+    @provider = create(:provider, id: 1)
+    AvailabilitySync.call(provider_id: @provider.id)
+  end
+
+  test "GET /providers/:provider_id/availabilities returns free slots (happy path)" do
+    base_monday = Time.zone.now.next_week(:monday)
+    from_time = base_monday.change(hour: 9, min: 0)
+    to_time   = base_monday.change(hour: 12, min: 0)
+
+    get provider_availabilities_path(@provider), params: { from: from_time.strftime("%Y-%m-%d %H:%M"), to: to_time.strftime("%Y-%m-%d %H:%M") }
+    assert_response :success
+
+    body = JSON.parse(@response.body)
+    assert_equal @provider.id, body["provider_id"]
+    assert_equal from_time.iso8601, body["from"]
+    assert_equal to_time.iso8601, body["to"]
+
+    slots = body["free_slots"]
+    expect1 = { "starts_at" => base_monday.change(hour: 9,  min: 0).iso8601,  "ends_at" => base_monday.change(hour: 9,  min: 30).iso8601 }
+    expect2 = { "starts_at" => base_monday.change(hour: 9,  min: 45).iso8601, "ends_at" => base_monday.change(hour: 10, min: 15).iso8601 }
+    expect3 = { "starts_at" => base_monday.change(hour: 11, min: 30).iso8601, "ends_at" => base_monday.change(hour: 12, min: 0).iso8601 }
+    assert_includes slots, expect1
+    assert_includes slots, expect2
+    assert_includes slots, expect3
+  end
+
+  test "GET returns 400 for invalid params" do
+    get provider_availabilities_path(@provider), params: { from: nil, to: nil }
+    assert_response :bad_request
+
+    body = JSON.parse(@response.body)
+    assert body["error"].present?
+  end
+
+  test "GET returns 404 for unknown provider" do
+    get provider_availabilities_path(provider_id: 9999), params: { from: "2025-09-22 09:00", to: "2025-09-22 12:00" }
+    assert_response :not_found
+
+    body = JSON.parse(@response.body)
+    assert body["error"].present?
   end
 end

--- a/test/factories/appointments.rb
+++ b/test/factories/appointments.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :appointment do
+    association :client
+    association :provider
+
+    starts_at { "2025-10-06 09:00" }
+    ends_at { "2025-10-06 10:00" }
+
+    status { :scheduled }
+  end
+end

--- a/test/factories/appointments.rb
+++ b/test/factories/appointments.rb
@@ -3,8 +3,12 @@ FactoryBot.define do
     association :client
     association :provider
 
-    starts_at { "2025-10-06 09:00" }
-    ends_at { "2025-10-06 10:00" }
+    transient do
+      base_day { Time.zone.now.next_week(:monday) }
+    end
+
+    starts_at { base_day.change(hour: 9, min: 0) }
+    ends_at { base_day.change(hour: 10, min: 0) }
 
     status { :scheduled }
   end

--- a/test/factories/availabilities.rb
+++ b/test/factories/availabilities.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :availability do
+    association :provider
+
+    source { "calendly" }
+    sequence(:external_id) { |n| "ext-#{n}" }
+
+    start_day_of_week { :monday }
+    start_time { "09:00" }
+
+    end_day_of_week { :monday }
+    end_time { "11:30" }
+  end
+end

--- a/test/factories/clients.rb
+++ b/test/factories/clients.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :client do
+  end
+end

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :provider do
+  end
+end

--- a/test/forms/time_range_params_test.rb
+++ b/test/forms/time_range_params_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class TimeRangeParamsTest < ActiveSupport::TestCase
   test "valid with proper ISO8601 from/to and to after from" do
     params = TimeRangeParams.new(from: "2025-10-06T09:00:00Z", to: "2025-10-06T10:00:00Z")
+
     assert params.valid?
     assert_instance_of Time, params.from
     assert_instance_of Time, params.to
@@ -17,6 +18,7 @@ class TimeRangeParamsTest < ActiveSupport::TestCase
 
   test "invalid when to is not after from" do
     params_equal = TimeRangeParams.new(from: "2025-10-06T10:00:00Z", to: "2025-10-06T10:00:00Z")
+
     assert_not params_equal.valid?
     assert params_equal.errors.of_kind?(:to, :greater_than)
   end
@@ -25,18 +27,21 @@ class TimeRangeParamsTest < ActiveSupport::TestCase
     past_from = 1.day.ago.iso8601
     future_to = 1.hour.from_now.iso8601
     params_clamped = TimeRangeParams.new(from: past_from, to: future_to)
+
     assert params_clamped.valid?
     assert params_clamped.from >= Time.zone.now - 1.second # allow tiny drift
   end
 
   test "to must be in the future (implicit via to > clamped from)" do
     params_with_to_before_from = TimeRangeParams.new(from: 1.minute.from_now.iso8601, to: 1.second.from_now.iso8601)
+
     assert_not params_with_to_before_from.valid?
     assert params_with_to_before_from.errors.of_kind?(:to, :greater_than)
   end
 
   test "when only from is missing shows presence error only" do
     params_only_to = TimeRangeParams.new(from: nil, to: 1.hour.from_now.iso8601)
+
     assert_not params_only_to.valid?
     assert params_only_to.errors.of_kind?(:from, :blank)
     refute params_only_to.errors.of_kind?(:to, :greater_than)
@@ -44,6 +49,7 @@ class TimeRangeParamsTest < ActiveSupport::TestCase
 
   test "when only to is missing shows presence error only" do
     params_only_from = TimeRangeParams.new(from: 1.hour.from_now.iso8601, to: nil)
+
     assert_not params_only_from.valid?
     assert params_only_from.errors.of_kind?(:to, :blank)
     refute params_only_from.errors.of_kind?(:to, :greater_than)

--- a/test/forms/time_range_params_test.rb
+++ b/test/forms/time_range_params_test.rb
@@ -11,6 +11,7 @@ class TimeRangeParamsTest < ActiveSupport::TestCase
 
   test "invalid when missing from or to" do
     params_missing = TimeRangeParams.new(from: nil, to: nil)
+
     assert_not params_missing.valid?
     assert params_missing.errors.of_kind?(:from, :blank)
     assert params_missing.errors.of_kind?(:to, :blank)

--- a/test/forms/time_range_params_test.rb
+++ b/test/forms/time_range_params_test.rb
@@ -1,8 +1,12 @@
 require "test_helper"
 
 class TimeRangeParamsTest < ActiveSupport::TestCase
+  setup do
+    @monday = Time.zone.now.next_week(:monday)
+  end
+
   test "valid with proper ISO8601 from/to and to after from" do
-    params = TimeRangeParams.new(from: "2025-10-06T09:00:00Z", to: "2025-10-06T10:00:00Z")
+    params = TimeRangeParams.new(from: @monday.change(hour: 9, min: 0).iso8601, to: @monday.change(hour: 10, min: 0).iso8601)
 
     assert params.valid?
     assert_instance_of Time, params.from
@@ -18,7 +22,8 @@ class TimeRangeParamsTest < ActiveSupport::TestCase
   end
 
   test "invalid when to is not after from" do
-    params_equal = TimeRangeParams.new(from: "2025-10-06T10:00:00Z", to: "2025-10-06T10:00:00Z")
+    equal_time = @monday.change(hour: 10, min: 0).iso8601
+    params_equal = TimeRangeParams.new(from: equal_time, to: equal_time)
 
     assert_not params_equal.valid?
     assert params_equal.errors.of_kind?(:to, :greater_than)

--- a/test/forms/time_range_params_test.rb
+++ b/test/forms/time_range_params_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class TimeRangeParamsTest < ActiveSupport::TestCase
+  test "valid with proper ISO8601 from/to and to after from" do
+    r = TimeRangeParams.new(from: "2025-10-06T09:00:00Z", to: "2025-10-06T10:00:00Z")
+    assert r.valid?
+    assert_instance_of Time, r.from
+    assert_instance_of Time, r.to
+  end
+
+  test "invalid when missing from or to" do
+    r = TimeRangeParams.new(from: nil, to: nil)
+    assert_not r.valid?
+    assert r.errors.of_kind?(:from, :blank)
+    assert r.errors.of_kind?(:to, :blank)
+  end
+
+  test "invalid when to is not after from" do
+    r = TimeRangeParams.new(from: "2025-10-06T10:00:00Z", to: "2025-10-06T10:00:00Z")
+    assert_not r.valid?
+    assert r.errors.of_kind?(:to, :greater_than)
+  end
+end

--- a/test/forms/time_range_params_test.rb
+++ b/test/forms/time_range_params_test.rb
@@ -29,13 +29,23 @@ class TimeRangeParamsTest < ActiveSupport::TestCase
     assert params_clamped.from >= Time.zone.now - 1.second # allow tiny drift
   end
 
-  test "to must be in the future (strictly)" do
-    params_with_to_now = TimeRangeParams.new(from: 1.minute.from_now.iso8601, to: Time.zone.now.iso8601)
-    assert_not params_with_to_now.valid?
-    assert params_with_to_now.errors.of_kind?(:to, :greater_than)
-
+  test "to must be in the future (implicit via to > clamped from)" do
     params_with_to_before_from = TimeRangeParams.new(from: 1.minute.from_now.iso8601, to: 1.second.from_now.iso8601)
     assert_not params_with_to_before_from.valid?
     assert params_with_to_before_from.errors.of_kind?(:to, :greater_than)
+  end
+
+  test "when only from is missing shows presence error only" do
+    params_only_to = TimeRangeParams.new(from: nil, to: 1.hour.from_now.iso8601)
+    assert_not params_only_to.valid?
+    assert params_only_to.errors.of_kind?(:from, :blank)
+    refute params_only_to.errors.of_kind?(:to, :greater_than)
+  end
+
+  test "when only to is missing shows presence error only" do
+    params_only_from = TimeRangeParams.new(from: 1.hour.from_now.iso8601, to: nil)
+    assert_not params_only_from.valid?
+    assert params_only_from.errors.of_kind?(:to, :blank)
+    refute params_only_from.errors.of_kind?(:to, :greater_than)
   end
 end

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -23,8 +23,8 @@ class AppointmentTest < ActiveSupport::TestCase
   test "ends_at must be after starts_at" do
     appointment = build(
       :appointment,
-      starts_at: "2025-09-22 10:00",
-      ends_at: "2025-09-22 09:59",
+      starts_at: @next_monday.change(hour: 10, min: 0),
+      ends_at: @next_monday.change(hour: 9, min: 59),
       status: :scheduled
     )
 
@@ -44,8 +44,8 @@ class AppointmentTest < ActiveSupport::TestCase
       :appointment,
       client: create(:client),
       provider: create(:provider),
-      starts_at: "2025-09-22 10:00",
-      ends_at: "2025-09-22 10:30",
+      starts_at: @next_monday.change(hour: 10, min: 0),
+      ends_at: @next_monday.change(hour: 10, min: 30),
       status: :scheduled
     )
 

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class AppointmentTest < ActiveSupport::TestCase
+  test "belongs to client and provider" do
+    appointment = create(:appointment)
+
+    assert appointment.client
+    assert appointment.provider
+  end
+
+  test "ends_at must be after starts_at" do
+    appointment = build(
+      :appointment,
+      starts_at: "2025-09-22 10:00",
+      ends_at: "2025-09-22 09:59",
+      status: :scheduled
+    )
+
+    assert_not appointment.valid?
+    assert_includes appointment.errors[:ends_at], "must be after starts_at"
+  end
+
+  test "status invalid is a validation error (enum validate: true)" do
+    appointment = build(:appointment, status: "invalid_status")
+
+    assert_not appointment.valid?
+    assert_includes appointment.errors[:status], "is not included in the list"
+  end
+
+  test "status enum prefixed helpers work" do
+    appointment = build(
+      :appointment,
+      starts_at: "2025-09-22 10:00",
+      ends_at: "2025-09-22 10:30"
+    )
+
+    assert appointment.status_scheduled?
+
+    appointment.status_canceled!
+
+    assert appointment.status_canceled?
+  end
+
+  test "presence validation for starts_at" do
+    appointment = build(:appointment, starts_at: nil)
+
+    assert_not appointment.valid?
+    assert_includes appointment.errors[:starts_at], "can't be blank"
+  end
+
+  test "presence validation for ends_at" do
+    appointment = build(:appointment, ends_at: nil)
+
+    assert_not appointment.valid?
+    assert_includes appointment.errors[:ends_at], "can't be blank"
+  end
+
+  test "presence validation for status" do
+    appointment = build(:appointment, status: nil)
+
+    assert_not appointment.valid?
+    assert_includes appointment.errors[:status], "can't be blank"
+  end
+end

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -17,14 +17,14 @@ class AppointmentTest < ActiveSupport::TestCase
     )
 
     assert_not appointment.valid?
-    assert_includes appointment.errors[:ends_at], "must be after starts_at"
+    assert appointment.errors.of_kind?(:ends_at, :greater_than)
   end
 
   test "status invalid is a validation error (enum validate: true)" do
     appointment = build(:appointment, status: "invalid_status")
 
     assert_not appointment.valid?
-    assert_includes appointment.errors[:status], "is not included in the list"
+    assert appointment.errors.of_kind?(:status, :inclusion)
   end
 
   test "status enum prefixed helpers work" do
@@ -45,20 +45,20 @@ class AppointmentTest < ActiveSupport::TestCase
     appointment = build(:appointment, starts_at: nil)
 
     assert_not appointment.valid?
-    assert_includes appointment.errors[:starts_at], "can't be blank"
+    assert appointment.errors.of_kind?(:starts_at, :blank)
   end
 
   test "presence validation for ends_at" do
     appointment = build(:appointment, ends_at: nil)
 
     assert_not appointment.valid?
-    assert_includes appointment.errors[:ends_at], "can't be blank"
+    assert appointment.errors.of_kind?(:ends_at, :blank)
   end
 
   test "presence validation for status" do
     appointment = build(:appointment, status: nil)
 
     assert_not appointment.valid?
-    assert_includes appointment.errors[:status], "can't be blank"
+    assert appointment.errors.of_kind?(:status, :blank)
   end
 end

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -4,6 +4,7 @@ class AppointmentTest < ActiveSupport::TestCase
   setup do
     @next_monday = Time.zone.now.next_week(:monday)
   end
+
   test "belongs to client and provider" do
     provider = create(:provider, id: 1)
     AvailabilitySync.call(provider_id: provider.id)

--- a/test/models/availability_test.rb
+++ b/test/models/availability_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+class AvailabilityTest < ActiveSupport::TestCase
+  test "enums accept symbols and generate natural predicates" do
+    availability = build(
+      :availability,
+      start_day_of_week: :monday,
+      start_time: "09:00",
+      end_day_of_week: :monday,
+      end_time: "09:30"
+    )
+
+    assert availability.starts_on_monday?
+    assert availability.ends_on_monday?
+  end
+
+  test "uniqueness on provider+source+external_id" do
+    existing = create(:availability, source: "calendly", external_id: "dup-1")
+
+    dup = build(
+      :availability,
+      provider: existing.provider,
+      source: existing.source,
+      external_id: existing.external_id,
+      start_day_of_week: :monday,
+      start_time: "10:00",
+      end_day_of_week: :monday,
+      end_time: "10:30"
+    )
+
+    assert_not dup.valid?
+    assert_includes dup.errors[:external_id], "has already been taken"
+  end
+
+  test "same-day end_time must be after start_time" do
+    availability = build(
+      :availability,
+      source: "calendly",
+      external_id: "test-2",
+      start_day_of_week: :monday,
+      start_time: "09:30",
+      end_day_of_week: :monday,
+      end_time: "09:00"
+    )
+
+    assert_not availability.valid?
+    assert_includes availability.errors[:end_time], "must be after start_time for same-day windows"
+  end
+
+  test "presence validations" do
+    required_attrs = %i[source external_id start_day_of_week end_day_of_week start_time end_time]
+
+    required_attrs.each do |attr|
+      availability = build(:availability)
+      availability.send("#{attr}=", nil)
+
+      assert_not availability.valid?, "expected #{attr} presence validation to fail"
+      assert_includes availability.errors[attr], "can't be blank"
+    end
+  end
+
+  test "cross-day window allows end_time before start_time" do
+    availability = build(
+      :availability,
+      start_day_of_week: :monday,
+      start_time: "23:30",
+      end_day_of_week: :tuesday,
+      end_time: "00:15"
+    )
+
+    assert availability.valid?
+  end
+
+  test "invalid day enum adds validation error" do
+    availability = build(:availability, start_day_of_week: :funday)
+
+    assert_not availability.valid?
+    assert availability.errors[:start_day_of_week].present?
+  end
+end

--- a/test/models/availability_test.rb
+++ b/test/models/availability_test.rb
@@ -29,7 +29,7 @@ class AvailabilityTest < ActiveSupport::TestCase
     )
 
     assert_not dup.valid?
-    assert_includes dup.errors[:external_id], "has already been taken"
+    assert dup.errors.of_kind?(:external_id, :taken)
   end
 
   test "same-day end_time must be after start_time" do
@@ -44,7 +44,7 @@ class AvailabilityTest < ActiveSupport::TestCase
     )
 
     assert_not availability.valid?
-    assert_includes availability.errors[:end_time], "must be after start_time for same-day windows"
+    assert availability.errors.of_kind?(:end_time, :greater_than)
   end
 
   test "presence validations" do
@@ -55,7 +55,7 @@ class AvailabilityTest < ActiveSupport::TestCase
       availability.send("#{attr}=", nil)
 
       assert_not availability.valid?, "expected #{attr} presence validation to fail"
-      assert_includes availability.errors[attr], "can't be blank"
+      assert availability.errors.of_kind?(attr, :blank)
     end
   end
 
@@ -75,6 +75,6 @@ class AvailabilityTest < ActiveSupport::TestCase
     availability = build(:availability, start_day_of_week: :funday)
 
     assert_not availability.valid?
-    assert availability.errors[:start_day_of_week].present?
+    assert availability.errors.of_kind?(:start_day_of_week, :inclusion)
   end
 end

--- a/test/models/availability_test.rb
+++ b/test/models/availability_test.rb
@@ -77,4 +77,30 @@ class AvailabilityTest < ActiveSupport::TestCase
     assert_not availability.valid?
     assert availability.errors.of_kind?(:start_day_of_week, :inclusion)
   end
+
+  # Helpers: start_dow / end_dow / days_until_end
+  test "start_dow and end_dow return integer weekdays" do
+    availability = build(:availability, start_day_of_week: :monday, end_day_of_week: :tuesday)
+
+    assert_equal 1, availability.start_dow
+    assert_equal 2, availability.end_dow
+  end
+
+  test "days_until_end is 0 for same-day windows" do
+    availability = build(:availability, start_day_of_week: :monday, end_day_of_week: :monday)
+
+    assert_equal 0, availability.days_until_end
+  end
+
+  test "days_until_end is 1 for overnight Monday to Tuesday" do
+    availability = build(:availability, start_day_of_week: :monday, end_day_of_week: :tuesday)
+
+    assert_equal 1, availability.days_until_end
+  end
+
+  test "days_until_end wraps across week (Monday to Sunday -> 6)" do
+    availability = build(:availability, start_day_of_week: :monday, end_day_of_week: :sunday)
+
+    assert_equal 6, availability.days_until_end
+  end
 end

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -12,4 +12,18 @@ class ClientTest < ActiveSupport::TestCase
 
     assert_equal 2, client.appointments.count
   end
+
+  test "restrict destroy when client has appointments" do
+    client = create(:client)
+    provider = create(:provider, id: 1)
+    AvailabilitySync.call(provider_id: provider.id)
+
+    next_monday = Time.zone.now.next_week(:monday)
+    create(:appointment, client:, provider:, starts_at: next_monday.change(hour: 9, min: 5), ends_at: next_monday.change(hour: 9, min: 25))
+
+    assert_no_difference("Appointment.count") do
+      assert_not client.destroy, "expected destroy to be restricted"
+      assert_includes client.errors.full_messages, "Cannot delete record because dependent appointments exist"
+    end
+  end
 end

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -3,9 +3,12 @@ require "test_helper"
 class ClientTest < ActiveSupport::TestCase
   test "has many appointments" do
     client = create(:client)
+    provider = create(:provider, id: 1)
+    AvailabilitySync.call(provider_id: provider.id)
 
-    create(:appointment, client:)
-    create(:appointment, client:)
+    next_monday = Time.zone.now.next_week(:monday)
+    create(:appointment, client:, provider:, starts_at: next_monday.change(hour: 9, min: 5), ends_at: next_monday.change(hour: 9, min: 25))
+    create(:appointment, client:, provider:, starts_at: next_monday.change(hour: 9, min: 45), ends_at: next_monday.change(hour: 10, min: 0))
 
     assert_equal 2, client.appointments.count
   end

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class ClientTest < ActiveSupport::TestCase
+  test "has many appointments" do
+    client = create(:client)
+
+    create(:appointment, client:)
+    create(:appointment, client:)
+
+    assert_equal 2, client.appointments.count
+  end
+end

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -20,4 +20,25 @@ class ProviderTest < ActiveSupport::TestCase
 
     assert_equal 2, provider.availabilities.count
   end
+
+  test "restrict destroy when provider has dependents" do
+    provider = create(:provider, id: 1)
+    AvailabilitySync.call(provider_id: provider.id)
+    client = create(:client)
+    next_monday = Time.zone.now.next_week(:monday)
+    create(:appointment, provider:, client:, starts_at: next_monday.change(hour: 9, min: 5), ends_at: next_monday.change(hour: 9, min: 25))
+
+    assert_no_difference("Appointment.count") do
+      assert_not provider.destroy, "expected destroy to be restricted"
+      assert_includes provider.errors.full_messages, "Cannot delete record because dependent availabilities exist"
+    end
+  end
+
+  test "restrict destroy when provider has availabilities" do
+    provider = create(:provider)
+    create(:availability, provider:)
+
+    assert_not provider.destroy, "expected destroy to be restricted"
+    assert_includes provider.errors.full_messages, "Cannot delete record because dependent availabilities exist"
+  end
 end

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class ProviderTest < ActiveSupport::TestCase
+  test "has many appointments" do
+    provider = create(:provider)
+
+    create(:appointment, provider:)
+    create(:appointment, provider:)
+
+    assert_equal 2, provider.appointments.count
+  end
+
+  test "has many availabilities" do
+    provider = create(:provider)
+
+    create(:availability, provider:)
+    create(:availability, provider:)
+
+    assert_equal 2, provider.availabilities.count
+  end
+end

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -2,10 +2,12 @@ require "test_helper"
 
 class ProviderTest < ActiveSupport::TestCase
   test "has many appointments" do
-    provider = create(:provider)
+    provider = create(:provider, id: 1)
+    AvailabilitySync.call(provider_id: provider.id)
 
-    create(:appointment, provider:)
-    create(:appointment, provider:)
+    next_monday = Time.zone.now.next_week(:monday)
+    create(:appointment, provider:, client: create(:client), starts_at: next_monday.change(hour: 9, min: 5), ends_at: next_monday.change(hour: 9, min: 25))
+    create(:appointment, provider:, client: create(:client), starts_at: next_monday.change(hour: 11, min: 30), ends_at: next_monday.change(hour: 11, min: 45))
 
     assert_equal 2, provider.appointments.count
   end

--- a/test/schemas/appointments_show.json
+++ b/test/schemas/appointments_show.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["id", "client_id", "provider_id", "status", "starts_at", "ends_at"],
+  "properties": {
+    "id": { "type": "integer" },
+    "client_id": { "type": "integer" },
+    "provider_id": { "type": "integer" },
+    "status": { "type": "string" },
+    "starts_at": { "type": "string" },
+    "ends_at": { "type": "string" }
+  }
+}
+

--- a/test/schemas/providers_availabilities_index.json
+++ b/test/schemas/providers_availabilities_index.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["provider_id", "from", "to", "free_slots"],
+  "properties": {
+    "provider_id": { "type": "integer" },
+    "from": { "type": "string" },
+    "to": { "type": "string" },
+    "free_slots": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["starts_at", "ends_at"],
+        "properties": {
+          "starts_at": { "type": "string" },
+          "ends_at": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/test/services/availability_sync_test.rb
+++ b/test/services/availability_sync_test.rb
@@ -7,7 +7,7 @@ class AvailabilitySyncTest < ActiveSupport::TestCase
 
   test "creates and is idempotent for provider 1 and returns counts" do
     result1 = AvailabilitySync.call(provider_id: 1)
-    
+
     assert result1.success?
     assert_equal({ created: 9, updated: 0, unchanged: 0, total: 9 }, result1.data[:counts])
 
@@ -79,5 +79,3 @@ class AvailabilitySyncTest < ActiveSupport::TestCase
     assert_equal({ created: 0, updated: 1, unchanged: 8, total: 9 }, result.data[:counts])
   end
 end
-
-

--- a/test/services/availability_sync_test.rb
+++ b/test/services/availability_sync_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class AvailabilitySyncTest < ActiveSupport::TestCase
+  setup do
+    create(:provider, id: 1)
+  end
+
+  test "creates and is idempotent for provider 1 and returns counts" do
+    result1 = AvailabilitySync.call(provider_id: 1)
+    
+    assert result1.success?
+    assert_equal({ created: 9, updated: 0, unchanged: 0, total: 9 }, result1.data[:counts])
+
+    # Second run should not create duplicates or updates
+    assert_no_difference -> { Availability.where(provider_id: 1).count } do
+      result2 = AvailabilitySync.call(provider_id: 1)
+      assert result2.success?
+      assert_equal({ created: 0, updated: 0, unchanged: 9, total: 9 }, result2.data[:counts])
+    end
+  end
+
+  test "maps days and times from Calendly payload" do
+    result = AvailabilitySync.call(provider_id: 1)
+    assert result.success?
+
+    early = Availability.find_by!(provider_id: 1, external_id: "p1-slot-early-morning")
+    assert early.starts_on_monday?
+    assert early.ends_on_monday?
+    assert_equal "06:30", early.start_time.strftime("%H:%M")
+    assert_equal "07:00", early.end_time.strftime("%H:%M")
+
+    cross = Availability.find_by!(provider_id: 1, external_id: "p1-slot-evening-cross-midnight")
+    assert cross.starts_on_monday?
+    assert cross.ends_on_tuesday?
+  end
+
+  test "creates all slots for provider 2" do
+    create(:provider, id: 2)
+    result = AvailabilitySync.call(provider_id: 2)
+    assert result.success?
+    assert_equal 3, Availability.where(provider_id: 2).count
+    assert_equal({ created: 3, updated: 0, unchanged: 0, total: 3 }, result.data[:counts])
+  end
+
+  test "returns failure and errors on invalid same-day window" do
+    bogus_client = Class.new do
+      def fetch_slots(_)
+        [
+          {
+            "id" => "bogus-1",
+            "source" => "calendly",
+            "starts_at" => { "day_of_week" => :monday, "time" => "10:00" },
+            "ends_at" => { "day_of_week" => :monday, "time" => "09:00" }
+          }
+        ]
+      end
+    end.new
+
+    create(:provider, id: 99)
+    result = AvailabilitySync.call(client: bogus_client, provider_id: 99)
+
+    assert_not result.success?
+
+    assert_equal 1, result.error[:counts][:total]
+    assert_equal 0, result.error[:counts][:created]
+    assert_equal 0, result.error[:counts][:updated]
+    assert_equal 0, result.error[:counts][:unchanged]
+    assert_equal "bogus-1", result.error[:errors].first[:external_id]
+  end
+
+  test "counts updated only when attributes changed" do
+    # seed
+    AvailabilitySync.call(provider_id: 1)
+    to_fix = Availability.find_by!(provider_id: 1, external_id: "p1-slot-morning-1")
+    to_fix.update!(end_time: "09:45")
+
+    result = AvailabilitySync.call(provider_id: 1)
+    assert result.success?
+    assert_equal({ created: 0, updated: 1, unchanged: 8, total: 9 }, result.data[:counts])
+  end
+end
+
+

--- a/test/services/providers/availabilities/date_helpers_test.rb
+++ b/test/services/providers/availabilities/date_helpers_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class Providers::Availabilities::DateHelpersTest < ActiveSupport::TestCase
+  include Providers::Availabilities::DateHelpers
+
+  test "dates_in_scope includes the day before from and up to to" do
+    from = Date.new(2025, 9, 23)
+    to = Date.new(2025, 9, 25)
+
+    result = dates_in_scope(from: from, to: to).to_a
+
+    assert_equal [ Date.new(2025, 9, 22), Date.new(2025, 9, 23), Date.new(2025, 9, 24), Date.new(2025, 9, 25) ], result
+  end
+end

--- a/test/services/providers/availabilities/date_helpers_test.rb
+++ b/test/services/providers/availabilities/date_helpers_test.rb
@@ -7,7 +7,7 @@ class Providers::Availabilities::DateHelpersTest < ActiveSupport::TestCase
     from = Date.new(2025, 9, 23)
     to = Date.new(2025, 9, 25)
 
-    result = dates_in_scope(from: from, to: to).to_a
+    result = dates_in_scope(from:, to:).to_a
 
     assert_equal [ Date.new(2025, 9, 22), Date.new(2025, 9, 23), Date.new(2025, 9, 24), Date.new(2025, 9, 25) ], result
   end

--- a/test/services/providers/availabilities/free_slots_test.rb
+++ b/test/services/providers/availabilities/free_slots_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+
+class Providers::Availabilities::FreeSlotsTest < ActiveSupport::TestCase
+  setup do
+    @provider = create(:provider, id: 1)
+    AvailabilitySync.call(provider_id: @provider.id)
+    @client = create(:client)
+  end
+
+  test "clamps a single window to the requested range" do
+    from = "2025-09-22 09:05" # Monday
+    to = "2025-09-22 09:25"
+
+    result = Providers::Availabilities::FreeSlots.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    slots = result.data[:free_slots]
+    assert_includes slots, { starts_at: from, ends_at: to }
+  end
+
+  test "splits around an overlapping appointment" do
+    # Window is 09:00–09:30; add appointment 09:10–09:20
+    create(:appointment, provider: @provider, client: @client,
+                         starts_at: "2025-09-22 09:10", ends_at: "2025-09-22 09:20")
+
+    from = "2025-09-22 09:00"
+    to = "2025-09-22 09:30"
+
+    result = Providers::Availabilities::FreeSlots.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    slots = result.data[:free_slots]
+    assert_includes slots, { starts_at: "2025-09-22 09:00", ends_at: "2025-09-22 09:10" }
+    assert_includes slots, { starts_at: "2025-09-22 09:20", ends_at: "2025-09-22 09:30" }
+  end
+
+  test "returns cross-midnight window portion" do
+    from = "2025-09-22 23:45" # Mon 23:45
+    to = "2025-09-23 00:30" # Tue 00:30
+
+    result = Providers::Availabilities::FreeSlots.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    slots = result.data[:free_slots]
+    assert_includes slots, { starts_at: from, ends_at: "2025-09-23 00:15" }
+  end
+
+  test "edge-touching appointments do not subtract time" do
+    # Window 13:00–13:45; appointments touching edges should not affect
+    create(:appointment, provider: @provider, client: @client,
+                         starts_at: "2025-09-22 12:00", ends_at: "2025-09-22 13:00")
+    create(:appointment, provider: @provider, client: @client,
+                         starts_at: "2025-09-22 13:45", ends_at: "2025-09-22 14:00")
+
+    from = "2025-09-22 13:00"
+    to = "2025-09-22 13:45"
+
+    result = Providers::Availabilities::FreeSlots.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    slots = result.data[:free_slots]
+    assert_includes slots, { starts_at: from, ends_at: to }
+  end
+
+  test "drops zero-length after clamp" do
+    # Range ends exactly at 09:00; window starts at 09:00
+    from = "2025-09-22 08:00"
+    to = "2025-09-22 09:00"
+
+    result = Providers::Availabilities::FreeSlots.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    slots = result.data[:free_slots]
+
+    # No slot starts at 09:00 exactly in the fixture? Ensure no zero-length records anyway
+    refute_includes slots, { starts_at: to, ends_at: to }
+  end
+
+  test "splits around two overlapping appointments" do
+    # Window 11:30–12:00; add apts 11:35–11:40 and 11:45–11:50
+    create(:appointment, provider: @provider, client: @client,
+                         starts_at: "2025-09-22 11:35", ends_at: "2025-09-22 11:40")
+    create(:appointment, provider: @provider, client: @client,
+                         starts_at: "2025-09-22 11:45", ends_at: "2025-09-22 11:50")
+
+    from = "2025-09-22 11:30"
+    to = "2025-09-22 12:00"
+
+    result = Providers::Availabilities::FreeSlots.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    slots = result.data[:free_slots]
+
+    assert_includes slots, { starts_at: "2025-09-22 11:30", ends_at: "2025-09-22 11:35" }
+    assert_includes slots, { starts_at: "2025-09-22 11:40", ends_at: "2025-09-22 11:45" }
+    assert_includes slots, { starts_at: "2025-09-22 11:50", ends_at: "2025-09-22 12:00" }
+  end
+
+  test "merges contiguous windows into a single slot" do
+    provider = create(:provider, id: 3)
+    AvailabilitySync.call(provider_id: provider.id)
+
+    from = "2025-09-25 10:00" # Thursday
+    to = "2025-09-25 11:30"
+
+    result = Providers::Availabilities::FreeSlots.call(provider:, from:, to:)
+    assert result.success?
+
+    slots = result.data[:free_slots]
+    assert_includes slots, { starts_at: from, ends_at: to }
+    # Should not return the two separate touching windows
+    refute_includes slots, { starts_at: "2025-09-25 10:00", ends_at: "2025-09-25 11:00" }
+    refute_includes slots, { starts_at: "2025-09-25 11:00", ends_at: "2025-09-25 11:30" }
+  end
+end

--- a/test/services/providers/availabilities/query_test.rb
+++ b/test/services/providers/availabilities/query_test.rb
@@ -4,11 +4,15 @@ class Providers::Availabilities::QueryTest < ActiveSupport::TestCase
   setup do
     @provider = create(:provider, id: 1)
     AvailabilitySync.call(provider_id: @provider.id)
+
+    @next_monday = Time.zone.now.next_week(:monday)
+    @next_tuesday = Time.zone.now.next_week(:tuesday)
+    @next_saturday = Time.zone.now.next_week(:saturday)
   end
 
   test "returns all simple Monday slots in range" do
-    from = Time.zone.parse("2025-09-22 06:00") # Monday
-    to = Time.zone.parse("2025-09-22 18:00")
+    from = @next_monday.change(hour: 6, min: 0)
+    to = @next_monday.change(hour: 18, min: 0)
 
     result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
     assert result.success?
@@ -27,9 +31,9 @@ class Providers::Availabilities::QueryTest < ActiveSupport::TestCase
   end
 
   test "includes overnight slot crossing midnight" do
-    from = Time.zone.parse("2025-09-22 23:45") # Monday 23:45
-    to = Time.zone.parse("2025-09-23 00:30") # Tuesday 00:30
-    
+    from = @next_monday.change(hour: 23, min: 45)
+    to = (@next_monday + 1.day).change(hour: 0, min: 30)
+
     result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
     assert result.success?
 
@@ -39,8 +43,8 @@ class Providers::Availabilities::QueryTest < ActiveSupport::TestCase
   end
 
   test "includes next day morning slot only on Tuesday" do
-    from = Time.zone.parse("2025-09-23 08:00") # Tuesday
-    to = Time.zone.parse("2025-09-23 11:00")
+    from = @next_tuesday.change(hour: 8, min: 0)
+    to = @next_tuesday.change(hour: 11, min: 0)
 
     result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
     assert result.success?
@@ -52,8 +56,8 @@ class Providers::Availabilities::QueryTest < ActiveSupport::TestCase
   end
 
   test "excludes slots outside the range" do
-    from = Time.zone.parse("2025-09-22 14:00")
-    to = Time.zone.parse("2025-09-22 16:00")
+    from = @next_monday.change(hour: 14, min: 0)
+    to = @next_monday.change(hour: 16, min: 0)
 
     result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
     assert result.success?
@@ -66,8 +70,8 @@ class Providers::Availabilities::QueryTest < ActiveSupport::TestCase
   end
 
   test "includes weekend slot only on Saturday" do
-    from = Time.zone.parse("2025-09-27 13:00") # Saturday
-    to = Time.zone.parse("2025-09-27 16:00")
+    from = @next_saturday.change(hour: 13, min: 0)
+    to = @next_saturday.change(hour: 16, min: 0)
 
     result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
     assert result.success?
@@ -78,14 +82,14 @@ class Providers::Availabilities::QueryTest < ActiveSupport::TestCase
   end
 
   test "handles back-to-back and gap slots distinctly" do
-    from = Time.zone.parse("2025-09-22 09:00")
-    to = Time.zone.parse("2025-09-22 10:30")
+    from = @next_monday.change(hour: 9, min: 0)
+    to = @next_monday.change(hour: 10, min: 30)
 
     result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
     assert result.success?
-    
+
     ids = result.data[:availabilities].map(&:external_id)
-    
+
     assert_includes ids, "p1-slot-morning-1"
     assert_includes ids, "p1-slot-morning-back-to-back"
     refute_includes ids, "p1-slot-lunch-gap-before"

--- a/test/services/providers/availabilities/query_test.rb
+++ b/test/services/providers/availabilities/query_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class Providers::Availabilities::QueryTest < ActiveSupport::TestCase
+  setup do
+    @provider = create(:provider, id: 1)
+    AvailabilitySync.call(provider_id: @provider.id)
+  end
+
+  test "returns all simple Monday slots in range" do
+    from = Time.zone.parse("2025-09-22 06:00") # Monday
+    to = Time.zone.parse("2025-09-22 18:00")
+
+    result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    ids = result.data[:availabilities].map(&:external_id)
+
+    assert_includes ids, "p1-slot-early-morning"
+    assert_includes ids, "p1-slot-morning-1"
+    assert_includes ids, "p1-slot-morning-back-to-back"
+    assert_includes ids, "p1-slot-lunch-gap-before"
+    assert_includes ids, "p1-slot-lunch-gap-after"
+    assert_includes ids, "p1-slot-late-afternoon"
+    refute_includes ids, "p1-slot-evening-cross-midnight"
+    refute_includes ids, "p1-slot-next-day-morning"
+    refute_includes ids, "p1-slot-weekend"
+  end
+
+  test "includes overnight slot crossing midnight" do
+    from = Time.zone.parse("2025-09-22 23:45") # Monday 23:45
+    to = Time.zone.parse("2025-09-23 00:30") # Tuesday 00:30
+    
+    result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    ids = result.data[:availabilities].map(&:external_id)
+
+    assert_includes ids, "p1-slot-evening-cross-midnight"
+  end
+
+  test "includes next day morning slot only on Tuesday" do
+    from = Time.zone.parse("2025-09-23 08:00") # Tuesday
+    to = Time.zone.parse("2025-09-23 11:00")
+
+    result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    ids = result.data[:availabilities].map(&:external_id)
+
+    assert_includes ids, "p1-slot-next-day-morning"
+    refute_includes ids, "p1-slot-evening-cross-midnight"
+  end
+
+  test "excludes slots outside the range" do
+    from = Time.zone.parse("2025-09-22 14:00")
+    to = Time.zone.parse("2025-09-22 16:00")
+
+    result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    ids = result.data[:availabilities].map(&:external_id)
+
+    refute_includes ids, "p1-slot-morning-1"
+    refute_includes ids, "p1-slot-evening-cross-midnight"
+    refute_includes ids, "p1-slot-next-day-morning"
+  end
+
+  test "includes weekend slot only on Saturday" do
+    from = Time.zone.parse("2025-09-27 13:00") # Saturday
+    to = Time.zone.parse("2025-09-27 16:00")
+
+    result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
+    assert result.success?
+
+    ids = result.data[:availabilities].map(&:external_id)
+
+    assert_includes ids, "p1-slot-weekend"
+  end
+
+  test "handles back-to-back and gap slots distinctly" do
+    from = Time.zone.parse("2025-09-22 09:00")
+    to = Time.zone.parse("2025-09-22 10:30")
+
+    result = Providers::Availabilities::Query.call(provider: @provider, from:, to:)
+    assert result.success?
+    
+    ids = result.data[:availabilities].map(&:external_id)
+    
+    assert_includes ids, "p1-slot-morning-1"
+    assert_includes ids, "p1-slot-morning-back-to-back"
+    refute_includes ids, "p1-slot-lunch-gap-before"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 require "factory_bot_rails"
+require "json_schemer"
 
 module ActiveSupport
   class TestCase
@@ -10,5 +11,12 @@ module ActiveSupport
 
     # Add more helper methods to be used by all tests here...
     include FactoryBot::Syntax::Methods
+
+    def assert_schema(schema_path, json)
+      schema_file = File.expand_path("../schemas/#{schema_path}", __FILE__)
+      schemer = JSONSchemer.schema(Pathname.new(schema_file))
+      errors = schemer.validate(json).to_a
+      assert errors.empty?, "Schema validation failed: #{errors.map { |e| e.slice('data_pointer', 'type', 'schema_pointer') }}"
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,15 +1,14 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "factory_bot_rails"
 
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
 
-    # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-    fixtures :all
-
     # Add more helper methods to be used by all tests here...
+    include FactoryBot::Syntax::Methods
   end
 end


### PR DESCRIPTION
Build a minimal scheduling API:
* Ingest weekly availabilities from a Calendly-like feed (service + upsert).
* Expose `GET` provider availabilities (filter by `from`/`to`).
* Support booking via `POST` `/appointments` (fits availability, no conflicts).
* Cancel via `DELETE` `/appointments/:id` (`status: canceled`).
* Cover with lean model and request tests, keep schema simple and consistent.